### PR TITLE
fix(web): render gated pages on SSR to resolve GSC "Page with redirect"

### DIFF
--- a/web/src/app/[lang]/ask/page.tsx
+++ b/web/src/app/[lang]/ask/page.tsx
@@ -11,7 +11,6 @@ import {
 import Fuse from "fuse.js";
 import type { Lang } from "../../../lib/i18n";
 import { useOnboardingGate } from "../../../lib/useOnboardingGate";
-import { usePrefs } from "../../../lib/prefs";
 import type { AgeBandKey } from "../../../lib/prefs";
 import { QUESTIONS, TOPIC_CONFIG, type QACategory } from "../../../data/questions";
 import { TeenShell } from "../../../components/TeenShell";
@@ -53,13 +52,12 @@ export default function AskPage() {
   const { lang: rawLang } = useParams<{ lang: string }>();
   const lang: Lang = rawLang === "es" ? "es" : "en";
   const prefs = useOnboardingGate(lang);
-  const [, loaded] = usePrefs();
 
-  if (!loaded) return null;
-  if (!prefs.ageBand) return null;
-  if (prefs.ageBand === "10-12") return <Ask1012 lang={lang} band="10-12" />;
+  // Default to the 13-15 teen variant when prefs aren't set yet (first-time
+  // visitors, search engines). Avoids returning blank HTML on SSR.
+  const band: AgeBandKey = prefs.ageBand ?? "13-15";
+  if (band === "10-12") return <Ask1012 lang={lang} band="10-12" />;
 
-  const band = prefs.ageBand as AgeBandKey;
   return (
     <TeenShell active="answers" lang={lang}>
       <AskTeen lang={lang} band={band} />

--- a/web/src/app/[lang]/case/page.tsx
+++ b/web/src/app/[lang]/case/page.tsx
@@ -7,7 +7,6 @@ import { useParams } from "next/navigation";
 import { ChevronLeft, ChevronDown, ChevronUp } from "lucide-react";
 import type { Lang } from "../../../lib/i18n";
 import { useOnboardingGate } from "../../../lib/useOnboardingGate";
-import { usePrefs } from "../../../lib/prefs";
 import type { AgeBandKey } from "../../../lib/prefs";
 import { TeenShell } from "../../../components/TeenShell";
 import { CaseTeen } from "../../../components/teen/CaseTeen";
@@ -82,13 +81,12 @@ export default function CasePage() {
   const { lang: rawLang } = useParams<{ lang: string }>();
   const lang: Lang = rawLang === "es" ? "es" : "en";
   const prefs = useOnboardingGate(lang);
-  const [, loaded] = usePrefs();
 
-  if (!loaded) return null;
-  if (!prefs.ageBand) return null;
-  if (prefs.ageBand === "10-12") return <Case1012 lang={lang} />;
+  // Default to the 13-15 teen variant when prefs aren't set yet (first-time
+  // visitors, search engines). Avoids returning blank HTML on SSR.
+  const band: AgeBandKey = prefs.ageBand ?? "13-15";
+  if (band === "10-12") return <Case1012 lang={lang} />;
 
-  const band = prefs.ageBand as AgeBandKey;
   return (
     <TeenShell active="case" lang={lang}>
       <CaseTeen lang={lang} band={band} />

--- a/web/src/app/[lang]/future/page.tsx
+++ b/web/src/app/[lang]/future/page.tsx
@@ -4,7 +4,6 @@ import { useParams } from "next/navigation";
 import { FileText } from "lucide-react";
 import type { Lang } from "../../../lib/i18n";
 import { useOnboardingGate } from "../../../lib/useOnboardingGate";
-import { usePrefs } from "../../../lib/prefs";
 import type { AgeBandKey } from "../../../lib/prefs";
 import { ScreenHero, SafeNotice } from "../../../components/ui";
 import { TeenShell } from "../../../components/TeenShell";
@@ -14,13 +13,12 @@ export default function FuturePage() {
   const { lang: rawLang } = useParams<{ lang: string }>();
   const lang: Lang = rawLang === "es" ? "es" : "en";
   const prefs = useOnboardingGate(lang);
-  const [, loaded] = usePrefs();
 
-  if (!loaded) return null;
-  if (!prefs.ageBand) return null;
-  if (prefs.ageBand === "10-12") return <Future1012 lang={lang} />;
+  // Default to the 13-15 teen variant when prefs aren't set yet (first-time
+  // visitors, search engines). Avoids returning blank HTML on SSR.
+  const band: AgeBandKey = prefs.ageBand ?? "13-15";
+  if (band === "10-12") return <Future1012 lang={lang} />;
 
-  const band = prefs.ageBand as AgeBandKey;
   return (
     <TeenShell active="future" lang={lang}>
       <FutureTeen lang={lang} band={band} />

--- a/web/src/app/[lang]/page.tsx
+++ b/web/src/app/[lang]/page.tsx
@@ -170,12 +170,13 @@ export default function HomePage() {
   const lang: Lang = rawLang === "es" ? "es" : "en";
   const prefs = useOnboardingGate(lang);
 
-  if (!prefs.ageBand) return null;
-  if (prefs.ageBand === "10-12") {
+  // Default to the 13-15 teen variant when prefs aren't set yet (first-time
+  // visitors, search engines). Avoids returning blank HTML on SSR.
+  const band: AgeBandKey = prefs.ageBand ?? "13-15";
+  if (band === "10-12") {
     return <Dashboard1012 lang={lang} />;
   }
 
-  const band = prefs.ageBand as AgeBandKey;
   return (
     <TeenShell active="dashboard" lang={lang}>
       <DashboardTeen lang={lang} band={band} />

--- a/web/src/app/[lang]/resources/page.tsx
+++ b/web/src/app/[lang]/resources/page.tsx
@@ -5,6 +5,7 @@ import { useEffect } from "react";
 import type { Lang } from "../../../lib/i18n";
 import { useOnboardingGate } from "../../../lib/useOnboardingGate";
 import { usePrefs } from "../../../lib/prefs";
+import type { AgeBandKey } from "../../../lib/prefs";
 import { TeenShell } from "../../../components/TeenShell";
 import { ResourcesTeen } from "../../../components/teen/ResourcesTeen";
 
@@ -15,17 +16,19 @@ export default function ResourcesPage() {
   const prefs = useOnboardingGate(lang);
   const [, loaded] = usePrefs();
 
+  // 10-12 users don't get a resources page — bounce them home once their
+  // prefs hydrate. Un-onboarded visitors (no localStorage yet) fall through
+  // to the 13-15 teen variant so search engines see real content.
   useEffect(() => {
     if (loaded && prefs.ageBand === "10-12") router.replace(`/${lang}`);
   }, [loaded, prefs.ageBand, lang, router]);
 
-  if (!loaded) return null;
-  if (!prefs.ageBand) return null;
-  if (prefs.ageBand === "10-12") return null;
+  const band: AgeBandKey = prefs.ageBand ?? "13-15";
+  if (band === "10-12") return null;
 
   return (
     <TeenShell active="resources" lang={lang}>
-      <ResourcesTeen lang={lang} band={prefs.ageBand} county={prefs.county ?? "Unknown"} />
+      <ResourcesTeen lang={lang} band={band} county={prefs.county ?? "Unknown"} />
     </TeenShell>
   );
 }

--- a/web/src/app/[lang]/rights/page.tsx
+++ b/web/src/app/[lang]/rights/page.tsx
@@ -6,7 +6,6 @@ import { Shield, ChevronDown, ChevronUp } from "lucide-react";
 import type { Lang } from "../../../lib/i18n";
 import { t } from "../../../lib/i18n";
 import { useOnboardingGate } from "../../../lib/useOnboardingGate";
-import { usePrefs } from "../../../lib/prefs";
 import type { AgeBandKey } from "../../../lib/prefs";
 import { RIGHTS } from "../../../data/rights";
 import { ScreenHero, SafeNotice } from "../../../components/ui";
@@ -19,15 +18,15 @@ export default function RightsPage() {
   const { lang: rawLang } = useParams<{ lang: string }>();
   const lang: Lang = rawLang === "es" ? "es" : "en";
   const prefs = useOnboardingGate(lang);
-  const [, loaded] = usePrefs();
 
-  if (!loaded) return null;
-  if (!prefs.ageBand) return null;
-  if (prefs.ageBand === "10-12") return <Rights1012 lang={lang} />;
+  // Default to the 13-15 teen variant when prefs aren't set yet (first-time
+  // visitors, search engines). Avoids returning blank HTML on SSR.
+  const band: AgeBandKey = prefs.ageBand ?? "13-15";
+  if (band === "10-12") return <Rights1012 lang={lang} />;
 
   return (
     <TeenShell active="rights" lang={lang}>
-      <RightsTeen lang={lang} band={prefs.ageBand} />
+      <RightsTeen lang={lang} band={band} />
     </TeenShell>
   );
 }

--- a/web/src/app/[lang]/team/page.tsx
+++ b/web/src/app/[lang]/team/page.tsx
@@ -7,7 +7,6 @@ import { useParams } from "next/navigation";
 import { ChevronLeft, ChevronDown, ChevronUp } from "lucide-react";
 import type { Lang } from "../../../lib/i18n";
 import { useOnboardingGate } from "../../../lib/useOnboardingGate";
-import { usePrefs } from "../../../lib/prefs";
 import type { AgeBandKey } from "../../../lib/prefs";
 import { TeenShell } from "../../../components/TeenShell";
 import { TeamTeen } from "../../../components/teen/TeamTeen";
@@ -102,16 +101,14 @@ export default function TeamPage() {
   const { lang: rawLang } = useParams<{ lang: string }>();
   const lang: Lang = rawLang === "es" ? "es" : "en";
   const prefs = useOnboardingGate(lang);
-  const [, loaded] = usePrefs();
 
-  if (!loaded) return null;
-  if (!prefs.ageBand) return null;
-
-  if (prefs.ageBand === "10-12") {
+  // Default to the 13-15 teen variant when prefs aren't set yet (first-time
+  // visitors, search engines). Avoids returning blank HTML on SSR.
+  const band: AgeBandKey = prefs.ageBand ?? "13-15";
+  if (band === "10-12") {
     return <Team1012 lang={lang} />;
   }
 
-  const band = prefs.ageBand as AgeBandKey;
   return (
     <TeenShell active="team" lang={lang}>
       <TeamTeen lang={lang} band={band} />

--- a/web/src/app/[lang]/wellness/page.tsx
+++ b/web/src/app/[lang]/wellness/page.tsx
@@ -7,7 +7,6 @@ import { useParams } from "next/navigation";
 import { ChevronLeft, Phone, MessageSquare, HeartPulse } from "lucide-react";
 import type { Lang } from "../../../lib/i18n";
 import { useOnboardingGate } from "../../../lib/useOnboardingGate";
-import { usePrefs } from "../../../lib/prefs";
 import { CRISIS_PINS } from "../../../data/constants";
 import { TeenShell } from "../../../components/TeenShell";
 import { WellnessTeen } from "../../../components/teen/WellnessTeen";
@@ -51,11 +50,11 @@ export default function WellnessPage() {
   const { lang: rawLang } = useParams<{ lang: string }>();
   const lang: Lang = rawLang === "es" ? "es" : "en";
   const prefs = useOnboardingGate(lang);
-  const [, loaded] = usePrefs();
 
-  if (!loaded) return null;
-  if (!prefs.ageBand) return null;
-  if (prefs.ageBand === "10-12") return <Wellness1012 lang={lang} />;
+  // Default to the 13-15 teen variant when prefs aren't set yet (first-time
+  // visitors, search engines). Avoids returning blank HTML on SSR.
+  const band = prefs.ageBand ?? "13-15";
+  if (band === "10-12") return <Wellness1012 lang={lang} />;
 
   return (
     <TeenShell active="wellness" lang={lang}>

--- a/web/src/lib/useOnboardingGate.ts
+++ b/web/src/lib/useOnboardingGate.ts
@@ -1,30 +1,18 @@
 "use client";
 
-import { useEffect } from "react";
-import { useRouter } from "next/navigation";
 import { usePrefs } from "./prefs";
 import type { Lang } from "./i18n";
 
 /**
- * Call this at the top of every screen page.
- * If onboarding hasn't been completed, redirects to /[lang]/setup.
+ * Returns the user's prefs. Pages that call this hook fall back to a default
+ * age band when none is set, so search engines and first-time visitors get
+ * indexable content. Onboarding is reached via the root language picker
+ * (`/` → `/[lang]/setup`), not by gating individual pages — gating with a
+ * client-side redirect produced "Page with redirect" reports in Google Search
+ * Console and shipped blank HTML to crawlers that didn't run the redirect.
  */
-export function useOnboardingGate(lang: Lang) {
-  const [prefs, loaded] = usePrefs();
-  const router = useRouter();
-
-  useEffect(() => {
-    // Only redirect after localStorage has been read (loaded=true).
-    // Without this guard the default prefs (onboardingDone: false) fire a
-    // redirect on every page load before the saved values are hydrated.
-    if (loaded && !prefs.onboardingDone) {
-      // Prevent redirecting search engine bots so they can index the page
-      const isBot = /bot|googlebot|crawler|spider|robot|crawling/i.test(navigator.userAgent);
-      if (!isBot) {
-        router.replace(`/${lang}/setup`);
-      }
-    }
-  }, [loaded, prefs.onboardingDone, lang, router]);
-
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+export function useOnboardingGate(_lang: Lang) {
+  const [prefs] = usePrefs();
   return prefs;
 }


### PR DESCRIPTION
## Summary

- Pages using `useOnboardingGate` returned `null` on SSR when `prefs.ageBand` was unset, leaving search engines and first-time visitors with blank HTML. The hook also fired a client-side `router.replace` to `/[lang]/setup`, which Googlebot's UA check skipped but other crawlers (and GSC URL inspection) saw — producing the "Page with redirect" reports for `/en/case`, `/es/case`, and the root.
- Defaults the band to `"13-15"` (most general teen variant) when no prefs are set, and removes the JS redirect from the gate. Onboarding still flows naturally from the root language picker → `/[lang]/setup`.
- Resources page keeps its 10-12 → `/[lang]` bounce (10-12 doesn't get a resources page) but defaults un-onboarded visitors to 13-15 so the page is indexable.

## What was deliberately NOT changed (and why)

- **HTTP→HTTPS** redirects — required by HSTS, will always show as "Page with redirect" in GSC. Informational.
- **apex↔www** redirect direction — that's a Render dashboard / DNS setting, not code. The `www.fosterhubaz.com` canonical declared in `layout.tsx` and `sitemap.ts` is correct; verify the redirect is a 301 (`curl -sI https://fosterhubaz.com/en/case`) and not a 302.

## Test plan

- [x] `npm run build` — clean, all `[lang]` routes prerendered as SSG (EN + ES)
- [x] `npm run lint` — clean, no warnings
- [x] Built `/en/case.html` is 56 KB and contains "First Safety Hearing"; `/en/rights.html` is 60 KB and contains "A.R.S. 8-529" — confirms real content in SSR HTML
- [ ] After deploy, click **Validate Fix** in GSC → "Page with redirect" report. The `/case` and root entries should clear; http://* and apex/* entries will likely return as expected (informational).
- [ ] Spot-check `https://www.fosterhubaz.com/en/case` in an incognito window with localStorage cleared — page should render the 13-15 teen variant immediately, no redirect to `/setup`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)