### PR TITLE
Fix TeenShell navigation scrolling and footer layout

### DIFF
--- a/web/src/components/TeenShell.tsx
+++ b/web/src/components/TeenShell.tsx
@@ -92,7 +92,7 @@ export function TeenShell({ lang, children }: TeenShellProps) {
           </div>
         </div>
 
-        <nav className="flex flex-col px-6 gap-2 flex-1">
+        <nav className="flex flex-col px-6 gap-2 flex-1 min-h-0 overflow-y-auto [scrollbar-width:none] [-ms-overflow-style:none] [&::-webkit-scrollbar]:hidden">
           {NAV_ITEMS.map((item) => {
             const isActive = item.id === active;
             const Icon = item.icon;
@@ -121,7 +121,7 @@ export function TeenShell({ lang, children }: TeenShellProps) {
         </nav>
 
         {/* Footer: band+lang badge + start-over */}
-        <div className="p-8">
+        <div className="p-8 flex-shrink-0">
           <TeenShellFooter lang={lang} confirmReset={confirmReset} setConfirmReset={setConfirmReset} handleStartOver={handleStartOver} />
         </div>
       </aside>
@@ -166,7 +166,7 @@ export function TeenShell({ lang, children }: TeenShellProps) {
               <X size={22} />
             </button>
           </div>
-          <nav className="flex flex-col px-4 gap-2 flex-1 pt-4">
+          <nav className="flex flex-col px-4 gap-2 flex-1 min-h-0 overflow-y-auto pt-4 [scrollbar-width:none] [-ms-overflow-style:none] [&::-webkit-scrollbar]:hidden">
             {NAV_ITEMS.map((item) => {
               const isActive = item.id === active;
               const Icon = item.icon;
@@ -188,7 +188,7 @@ export function TeenShell({ lang, children }: TeenShellProps) {
               );
             })}
           </nav>
-          <div className="p-6">
+          <div className="p-6 flex-shrink-0">
             <TeenShellFooter lang={lang} confirmReset={confirmReset} setConfirmReset={setConfirmReset} handleStartOver={handleStartOver} />
           </div>
         </div>


### PR DESCRIPTION
## Summary
Fixes layout issues in the TeenShell component where the navigation menu could overflow without scrolling and the footer could be pushed off-screen on smaller viewports.

## Changes
- **Navigation scrolling**: Added `min-h-0`, `overflow-y-auto`, and cross-browser scrollbar-hiding classes to both desktop and mobile navigation elements to enable proper scrolling when nav items exceed available space
- **Footer positioning**: Added `flex-shrink-0` to footer containers (both desktop sidebar and mobile drawer) to prevent them from being compressed and ensure they remain visible at the bottom of the layout

## Implementation Details
The TeenShell uses a flexbox column layout where the navigation needs to be scrollable while the footer remains fixed at the bottom. The `min-h-0` property is necessary on flex children to allow overflow scrolling to work correctly. The scrollbar-hiding classes (`[scrollbar-width:none]`, `[-ms-overflow-style:none]`, `[&::-webkit-scrollbar]:hidden`) provide cross-browser support for hiding scrollbars while maintaining scroll functionality.

These changes apply to both the desktop sidebar navigation (line 95) and mobile drawer navigation (line 169), as well as their respective footer containers (lines 124 and 191).

https://claude.ai/code/session_01PzSnNHu7ydc8JE9BjQox4V