### PR TITLE
Improve responsive layout with fluid sizing on welcome page

### DIFF
--- a/web/src/app/page.tsx
+++ b/web/src/app/page.tsx
@@ -15,12 +15,12 @@ export default function RootPage() {
 
   return (
     <div className="min-h-svh bg-[#FDF9F3] text-[#35322d] font-['Outfit',_sans-serif] flex justify-center items-center">
-      <div className="w-full max-w-[480px] max-h-svh overflow-y-auto shadow-2xl bg-[#FDF9F3] relative flex flex-col overflow-x-hidden">
+      <div className="w-full max-w-[480px] min-h-svh max-h-svh overflow-y-auto shadow-2xl bg-[#FDF9F3] relative flex flex-col overflow-x-hidden">
 
         {/* Top area — icon + headline */}
-        <div className="px-6 pt-12 pb-6 flex flex-col items-center relative z-10 w-full text-center">
+        <div className="px-6 pt-[clamp(1rem,3vh,3rem)] pb-[clamp(0.5rem,1.5vh,1.5rem)] flex flex-col items-center relative z-10 w-full text-center flex-1 justify-center">
 
-          <div className="w-40 h-40 sm:w-48 sm:h-48 rounded-full bg-white shadow-lg border-[6px] border-white flex justify-center items-center overflow-hidden mb-6 relative">
+          <div className="w-[clamp(6rem,18vh,12rem)] h-[clamp(6rem,18vh,12rem)] rounded-full bg-white shadow-lg border-[6px] border-white flex justify-center items-center overflow-hidden mb-[clamp(0.75rem,2vh,1.5rem)] relative shrink-0">
             <Image
               src="/onboarding/welcome_icon.png"
               alt="Welcome"
@@ -31,15 +31,15 @@ export default function RootPage() {
             />
           </div>
 
-          <div className="text-[#136d41] font-extrabold text-[11px] mb-4 uppercase tracking-[0.2em] bg-[#136d41]/10 px-4 py-1.5 rounded-full">
+          <div className="text-[#136d41] font-extrabold text-[11px] mb-[clamp(0.5rem,1.5vh,1rem)] uppercase tracking-[0.2em] bg-[#136d41]/10 px-4 py-1.5 rounded-full">
             FosterHub AZ
           </div>
 
-          <h2 className="text-4xl sm:text-[2.75rem] font-extrabold text-[#115e59] mb-4 leading-[1.1]">
+          <h2 className="text-[clamp(1.75rem,5vh,2.75rem)] font-extrabold text-[#115e59] mb-[clamp(0.5rem,1.5vh,1rem)] leading-[1.1]">
             {selected === "es" ? "Este lugar es\npara ti." : "This place is\nfor you."}
           </h2>
 
-          <p className="text-slate-600 font-medium text-[16px] sm:text-lg leading-relaxed max-w-sm mb-6 px-2">
+          <p className="text-slate-600 font-medium text-[clamp(0.9rem,1.8vh,1.125rem)] leading-relaxed max-w-sm mb-[clamp(0.75rem,2vh,1.5rem)] px-2">
             {selected === "es"
               ? "El cuidado adoptivo puede ser confuso. Este es un espacio tranquilo y seguro para encontrar respuestas reales y conocer tus derechos."
               : "Foster care can be confusing and overwhelming. This is a calm, safe space to find real answers and learn your rights."}
@@ -52,9 +52,9 @@ export default function RootPage() {
         </div>
 
         {/* Bottom drawer — language selection */}
-        <div className="bg-white rounded-t-[2.5rem] px-8 pt-8 pb-10 shadow-[0_-15px_40px_-15px_rgba(0,0,0,0.05)] relative z-20 flex flex-col">
+        <div className="bg-white rounded-t-[2.5rem] px-8 pt-[clamp(1rem,2.5vh,2rem)] pb-[clamp(1rem,3vh,2.5rem)] shadow-[0_-15px_40px_-15px_rgba(0,0,0,0.05)] relative z-20 flex flex-col shrink-0">
 
-          <div className="flex items-center justify-between mb-6">
+          <div className="flex items-center justify-between mb-[clamp(0.75rem,2vh,1.5rem)]">
             <h3 className="text-2xl font-extrabold text-[#35322d]">
               {selected === "es" ? "Elige tu idioma" : "Select language"}
             </h3>
@@ -64,18 +64,18 @@ export default function RootPage() {
             </div>
           </div>
 
-          <div className="grid grid-cols-2 gap-4 mb-6">
+          <div className="grid grid-cols-2 gap-4 mb-[clamp(0.75rem,2vh,1.5rem)]">
             <button
               onClick={() => setSelected("en")}
-              className={`relative aspect-[4/3] rounded-[2rem] p-4 flex flex-col justify-center items-center text-center transition-all duration-300 ease-out border-[3px] ${
+              className={`relative aspect-[5/3] rounded-[2rem] p-4 flex flex-col justify-center items-center text-center transition-all duration-300 ease-out border-[3px] ${
                 selected === "en"
                   ? "bg-gradient-to-br from-[#fffdf5] to-[#fff4cc] border-[#fbbf24] shadow-sm scale-[1.02]"
                   : "bg-slate-50 border-transparent shadow-sm hover:bg-slate-100"
               }`}
             >
               {selected === "en" && (
-                <div className="absolute top-4 right-4 bg-white rounded-full p-0.5 shadow-sm">
-                  <CheckCircle2 size={24} className="fill-[#f59e0b] text-white" />
+                <div className="absolute top-3 right-3 bg-white rounded-full p-0.5 shadow-sm">
+                  <CheckCircle2 size={22} className="fill-[#f59e0b] text-white" />
                 </div>
               )}
               <span className={`font-extrabold text-2xl tracking-tight ${selected === "en" ? "text-[#78350f]" : "text-slate-500"}`}>
@@ -88,15 +88,15 @@ export default function RootPage() {
 
             <button
               onClick={() => setSelected("es")}
-              className={`relative aspect-[4/3] rounded-[2rem] p-4 flex flex-col justify-center items-center text-center transition-all duration-300 ease-out border-[3px] ${
+              className={`relative aspect-[5/3] rounded-[2rem] p-4 flex flex-col justify-center items-center text-center transition-all duration-300 ease-out border-[3px] ${
                 selected === "es"
                   ? "bg-gradient-to-br from-[#f0f9ff] to-[#e0f2fe] border-[#38bdf8] shadow-sm scale-[1.02]"
                   : "bg-slate-50 border-transparent shadow-sm hover:bg-slate-100"
               }`}
             >
               {selected === "es" && (
-                <div className="absolute top-4 right-4 bg-white rounded-full p-0.5 shadow-sm">
-                  <CheckCircle2 size={24} className="fill-[#0284c7] text-white" />
+                <div className="absolute top-3 right-3 bg-white rounded-full p-0.5 shadow-sm">
+                  <CheckCircle2 size={22} className="fill-[#0284c7] text-white" />
                 </div>
               )}
               <span className={`font-extrabold text-2xl tracking-tight ${selected === "es" ? "text-[#0c4a6e]" : "text-slate-500"}`}>
@@ -108,7 +108,7 @@ export default function RootPage() {
             </button>
           </div>
 
-          <div className="h-[72px]">
+          <div className="h-[clamp(56px,8vh,72px)]">
             {selected && (
               <button
                 onClick={handleNext}


### PR DESCRIPTION
## Summary
Refactored the welcome/language-selection page (`web/src/app/page.tsx`) to use fluid, viewport-aware sizing instead of fixed breakpoints. This ensures better visual consistency and spacing across all device sizes, from small phones to tablets.

## Key Changes
- **Container height**: Changed from fixed `max-h-svh` to `min-h-svh max-h-svh` to ensure the container always fills the viewport
- **Top section spacing**: Replaced fixed `pt-12 pb-6` with `clamp()` values (`pt-[clamp(1rem,3vh,3rem)]`, `pb-[clamp(0.5rem,1.5vh,1.5rem)]`) and added `flex-1 justify-center` for vertical centering
- **Welcome icon**: Changed from fixed `w-40 h-40 sm:w-48 sm:h-48` to fluid `w-[clamp(6rem,18vh,12rem)] h-[clamp(6rem,18vh,12rem)]` with `shrink-0` to prevent collapse
- **Typography sizing**: Updated heading and paragraph text to use `clamp()` for responsive scaling:
  - Subtitle badge: `mb-[clamp(0.5rem,1.5vh,1rem)]`
  - Main heading: `text-[clamp(1.75rem,5vh,2.75rem)]`
  - Body text: `text-[clamp(0.9rem,1.8vh,1.125rem)]`
- **Bottom drawer**: Applied `clamp()` to padding (`pt-[clamp(1rem,2.5vh,2rem)]`, `pb-[clamp(1rem,3vh,2.5rem)]`) and added `shrink-0` to prevent compression
- **Language buttons**: Changed aspect ratio from `aspect-[4/3]` to `aspect-[5/3]` for wider buttons; adjusted checkmark icon positioning and size (`top-3 right-3`, `size-22`)
- **Spacing consistency**: Unified margin values throughout using `clamp()` for consistent rhythm across viewport sizes

## Implementation Details
- Uses CSS `clamp(min, preferred, max)` for all spacing and sizing to create smooth scaling between breakpoints
- Maintains visual hierarchy while adapting to different screen sizes
- Prevents layout shift and ensures content remains centered and properly proportioned on all devices
- Checkmark icons slightly reduced in size and repositioned for better visual balance with the new button proportions

https://claude.ai/code/session_01PzSnNHu7ydc8JE9BjQox4V