### PR TITLE
Make setup page responsive with viewport-relative sizing

### DIFF
--- a/web/src/app/[lang]/setup/page.tsx
+++ b/web/src/app/[lang]/setup/page.tsx
@@ -93,12 +93,12 @@ export default function SetupPage() {
 
   return (
     <div className="fixed inset-0 z-50 bg-[#FDF9F3] text-[#35322d] font-['Outfit',_sans-serif] flex justify-center items-center overflow-y-auto">
-      <div className="w-full max-w-[480px] max-h-full flex flex-col overflow-y-auto">
+      <div className="w-full max-w-[480px] min-h-svh max-h-svh flex flex-col overflow-y-auto">
 
         {/* Top area — icon + headline */}
-        <div className="px-6 pt-12 pb-6 flex flex-col items-center relative z-10 w-full text-center">
+        <div className="px-6 pt-[clamp(1rem,3vh,3rem)] pb-[clamp(0.5rem,1.5vh,1.5rem)] flex flex-col items-center relative z-10 w-full text-center flex-1 justify-center">
 
-          <div className="w-32 h-32 sm:w-40 sm:h-40 rounded-full bg-white shadow-lg border-[6px] border-white flex justify-center items-center overflow-hidden mb-6">
+          <div className="w-[clamp(5rem,16vh,10rem)] h-[clamp(5rem,16vh,10rem)] rounded-full bg-white shadow-lg border-[6px] border-white flex justify-center items-center overflow-hidden mb-[clamp(0.75rem,2vh,1.5rem)] shrink-0">
             <Image
               src="/onboarding/welcome_icon.png"
               alt=""
@@ -110,15 +110,15 @@ export default function SetupPage() {
             />
           </div>
 
-          <div className="text-[#136d41] font-extrabold text-[11px] mb-4 uppercase tracking-[0.2em] bg-[#136d41]/10 px-4 py-1.5 rounded-full">
+          <div className="text-[#136d41] font-extrabold text-[11px] mb-[clamp(0.5rem,1.5vh,1rem)] uppercase tracking-[0.2em] bg-[#136d41]/10 px-4 py-1.5 rounded-full">
             FosterHub AZ
           </div>
 
-          <h2 className="text-4xl sm:text-[2.75rem] font-extrabold text-[#115e59] mb-4 leading-[1.1]">
+          <h2 className="text-[clamp(1.75rem,5vh,2.75rem)] font-extrabold text-[#115e59] mb-[clamp(0.5rem,1.5vh,1rem)] leading-[1.1]">
             {lang === "es" ? "Este lugar es\npara ti." : "This place is\nfor you."}
           </h2>
 
-          <p className="text-slate-600 font-medium text-[16px] sm:text-lg leading-relaxed max-w-sm mb-6 px-2">
+          <p className="text-slate-600 font-medium text-[clamp(0.9rem,1.8vh,1.125rem)] leading-relaxed max-w-sm mb-[clamp(0.75rem,2vh,1.5rem)] px-2">
             {lang === "es"
               ? "El cuidado adoptivo puede ser confuso. Este es un espacio tranquilo y seguro para encontrar respuestas reales y conocer tus derechos."
               : "Foster care can be confusing and overwhelming. This is a calm, safe space to find real answers and learn your rights."}
@@ -131,9 +131,9 @@ export default function SetupPage() {
         </div>
 
         {/* Bottom drawer */}
-        <div className="bg-white rounded-t-[2.5rem] px-6 sm:px-8 pt-8 pb-10 shadow-[0_-15px_40px_-15px_rgba(0,0,0,0.05)] flex flex-col">
+        <div className="bg-white rounded-t-[2.5rem] px-6 sm:px-8 pt-[clamp(1rem,2.5vh,2rem)] pb-[clamp(1rem,3vh,2.5rem)] shadow-[0_-15px_40px_-15px_rgba(0,0,0,0.05)] flex flex-col shrink-0">
 
-          <div className="flex items-center justify-between mb-6">
+          <div className="flex items-center justify-between mb-[clamp(0.75rem,2vh,1.5rem)]">
             <h3 className="text-[1.35rem] sm:text-2xl font-extrabold text-[#35322d]">
               {stepQuestion}
             </h3>
@@ -142,14 +142,14 @@ export default function SetupPage() {
 
           {/* ── Step 0: Age ── */}
           {step === 0 && (
-            <div className="grid grid-cols-2 gap-3 sm:gap-4 mb-8">
+            <div className="grid grid-cols-2 gap-3 sm:gap-4 mb-[clamp(1rem,3vh,2rem)]">
               {AGE_OPTIONS.map((opt) => {
                 const isSelected = ageBand === opt.id;
                 return (
                   <button
                     key={opt.id}
                     onClick={() => setAgeBand(opt.id)}
-                    className={`relative flex flex-col justify-center items-center text-center transition-all duration-300 ease-out border-[3px] rounded-[1.5rem] p-3 sm:p-4 min-h-[110px] ${
+                    className={`relative flex flex-col justify-center items-center text-center transition-all duration-300 ease-out border-[3px] rounded-[1.5rem] p-3 sm:p-4 min-h-[clamp(86px,11vh,110px)] ${
                       isSelected
                         ? "bg-gradient-to-br from-[#E6F8EA] to-[#D5F2DB] border-[#136d41] shadow-md scale-[1.02]"
                         : "bg-slate-50 border-transparent shadow-sm hover:bg-slate-100 hover:scale-[1.01]"
@@ -174,11 +174,11 @@ export default function SetupPage() {
 
           {/* ── Step 1: County ── */}
           {step === 1 && (
-            <div className="mb-8">
+            <div className="mb-[clamp(1rem,3vh,2rem)]">
               <p className="text-xs text-slate-500 mb-3">
                 {lang === "es" ? "Esto nos ayuda a mostrarte recursos locales." : "This helps us show you local resources."}
               </p>
-              <div className="grid grid-cols-2 gap-2 max-h-64 overflow-y-auto pr-1">
+              <div className="grid grid-cols-2 gap-2 max-h-[clamp(180px,30vh,256px)] overflow-y-auto pr-1">
                 <button
                   onClick={() => { setCounty("Unknown"); setStep(2); }}
                   className={`col-span-2 rounded-2xl px-3 py-2.5 text-center text-sm font-semibold ring-1 transition-all ${
@@ -208,7 +208,7 @@ export default function SetupPage() {
 
           {/* ── Step 2: Tribal ── */}
           {step === 2 && (
-            <div className="grid grid-cols-2 gap-3 sm:gap-4 mb-8">
+            <div className="grid grid-cols-2 gap-3 sm:gap-4 mb-[clamp(1rem,3vh,2rem)]">
               {[
                 { val: true,  labelEn: "Yes",       labelEs: "Sí",      descEn: "I have tribal connections",    descEs: "Tengo conexiones tribales" },
                 { val: false, labelEn: "No / Not sure", labelEs: "No / No sé", descEn: "I don't have any tribal connections", descEs: "No tengo conexiones tribales" },
@@ -218,7 +218,7 @@ export default function SetupPage() {
                   <button
                     key={String(opt.val)}
                     onClick={() => setTribal(opt.val)}
-                    className={`relative flex flex-col justify-center items-center text-center transition-all duration-300 ease-out border-[3px] rounded-[1.5rem] p-3 sm:p-4 min-h-[110px] ${
+                    className={`relative flex flex-col justify-center items-center text-center transition-all duration-300 ease-out border-[3px] rounded-[1.5rem] p-3 sm:p-4 min-h-[clamp(86px,11vh,110px)] ${
                       isSelected
                         ? "bg-gradient-to-br from-[#E6F8EA] to-[#D5F2DB] border-[#136d41] shadow-md scale-[1.02]"
                         : "bg-slate-50 border-transparent shadow-sm hover:bg-slate-100 hover:scale-[1.01]"
@@ -243,17 +243,17 @@ export default function SetupPage() {
 
           {/* Navigation buttons — hidden on county step (auto-advances on click) */}
           {step !== 1 && (
-            <div className="flex items-stretch gap-3 mb-6">
+            <div className="flex items-stretch gap-3 mb-[clamp(0.75rem,2vh,1.5rem)]">
               <button
                 onClick={handleBack}
-                className="px-6 py-4 rounded-[1.5rem] font-bold text-[16px] text-slate-500 bg-slate-100 hover:bg-slate-200 transition-colors"
+                className="px-6 py-[clamp(0.75rem,2vh,1rem)] rounded-[1.5rem] font-bold text-[16px] text-slate-500 bg-slate-100 hover:bg-slate-200 transition-colors"
               >
                 {lang === "es" ? "Atrás" : "Back"}
               </button>
               <button
                 onClick={handleNext}
                 disabled={!isReady}
-                className={`flex-1 py-4 rounded-[1.5rem] font-extrabold text-[16px] flex items-center justify-center gap-2 transition-all duration-300 ${
+                className={`flex-1 py-[clamp(0.75rem,2vh,1rem)] rounded-[1.5rem] font-extrabold text-[16px] flex items-center justify-center gap-2 transition-all duration-300 ${
                   isReady
                     ? "bg-[#136d41] text-white hover:bg-[#0f5c35] shadow-md hover:shadow-lg"
                     : "bg-slate-100 text-slate-400 cursor-not-allowed"
@@ -267,10 +267,10 @@ export default function SetupPage() {
 
           {/* County step back button */}
           {step === 1 && (
-            <div className="mb-6">
+            <div className="mb-[clamp(0.75rem,2vh,1.5rem)]">
               <button
                 onClick={() => setStep(0)}
-                className="w-full px-6 py-4 rounded-[1.5rem] font-bold text-[16px] text-slate-500 bg-slate-100 hover:bg-slate-200 transition-colors"
+                className="w-full px-6 py-[clamp(0.75rem,2vh,1rem)] rounded-[1.5rem] font-bold text-[16px] text-slate-500 bg-slate-100 hover:bg-slate-200 transition-colors"
               >
                 {lang === "es" ? "Atrás" : "Back"}
               </button>


### PR DESCRIPTION
## Summary
Refactored the setup/onboarding page to use responsive, viewport-relative sizing instead of fixed breakpoints. This ensures the layout adapts fluidly across all device sizes and viewport heights, improving the experience on tablets, landscape phones, and other non-standard screen dimensions.

## Key Changes
- **Container sizing**: Changed main container from `max-h-full` to `min-h-svh max-h-svh` (small viewport height) to ensure full viewport coverage
- **Spacing**: Replaced fixed `pt-12 pb-6` with `clamp()` functions (e.g., `pt-[clamp(1rem,3vh,3rem)]`) for padding that scales with viewport height
- **Typography**: Updated heading sizes from `text-4xl sm:text-[2.75rem]` to `text-[clamp(1.75rem,5vh,2.75rem)]` for fluid scaling
- **Component dimensions**: 
  - Icon container: `w-32 h-32 sm:w-40 sm:h-40` → `w-[clamp(5rem,16vh,10rem)] h-[clamp(5rem,16vh,10rem)]`
  - Button heights: `py-4` → `py-[clamp(0.75rem,2vh,1rem)]`
  - Grid gaps and margins: Updated to use `clamp()` for consistent scaling
- **Layout flexibility**: Added `flex-1 justify-center` to top section and `shrink-0` to bottom drawer to maintain proper flex distribution
- **Scrollable areas**: Updated `max-h-64` to `max-h-[clamp(180px,30vh,256px)]` for responsive scroll container sizing

## Implementation Details
- Uses CSS `clamp()` for all responsive values, ensuring smooth scaling between min/max bounds
- Leverages viewport height (`vh`) units for vertical spacing to adapt to different screen orientations
- Maintains visual hierarchy and touch targets across all device sizes
- Preserves existing color scheme, typography weights, and interactive states

https://claude.ai/code/session_01PzSnNHu7ydc8JE9BjQox4V